### PR TITLE
Remove unnecessary escaping in the composer.json

### DIFF
--- a/build-advisories/composer.json
+++ b/build-advisories/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "roave\/security-advisories-builder",
-    "description": "Build tool for roave\/roave-security-advisories",
+    "name": "roave/security-advisories-builder",
+    "description": "Build tool for roave/roave-security-advisories",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
this makes the string more readable. And other places using a ``/`` (for instance in requirements) were not escaping it