### PR TITLE
Simplify Version#fromString

### DIFF
--- a/build-advisories/src/Roave/SecurityAdvisories/Version.php
+++ b/build-advisories/src/Roave/SecurityAdvisories/Version.php
@@ -35,12 +35,7 @@ final class Version
             throw new \InvalidArgumentException(sprintf('Given version "%s" is not a valid version string', $version));
         }
 
-        return new self(array_values(array_map(
-            function ($versionNumber) {
-                return (int) $versionNumber;
-            },
-            explode('.', $version)
-        )));
+        return new self(array_map('intval', explode('.', $version)));
     }
 
     /**


### PR DESCRIPTION
array_values did not do anything as explode already returns a zero-indexed array.
The build-in php function `intval` does exactly what the lambda does.