### PR TITLE
readme: use --dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package ensures that your application doesn't have installed dependencies w
 ## Installation
 
 ```sh
-composer require roave/security-advisories:dev-master
+composer require --dev roave/security-advisories:dev-master
 ```
 
 ## Usage


### PR DESCRIPTION
Quoting readme:
> This package is therefore only suited for installation in the root of your deployable project.

therefore move the dependency to `require-dev` section.