### PR TITLE
Add Humbug/file_get_contents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
         "onelogin/php-saml": "<2.10.4",
         "oro/crm": ">=1.7,<1.7.4",
         "oro/platform": ">=1.7,<1.7.4",
+        "padraic/humbug_get_contents": "<1.1.2",
         "phpmailer/phpmailer": ">=5,<5.2.24",
         "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
         "phpxmlrpc/extras": "<0.6.1",


### PR DESCRIPTION
cf. https://github.com/humbug/file_get_contents/pull/23, `padraic/file_get_contents` prior to 1.1.2 is vulnerable (CVE-2016-5385).