### PR TITLE
Add link to GitHub Advisory Database to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ This package is therefore only suited for installation in the root of your deplo
 ## Sources
 
 This package extracts information about existing security issues in various composer projects from 
-the [FriendsOfPHP/security-advisories](https://github.com/FriendsOfPHP/security-advisories) repository.
+the [FriendsOfPHP/security-advisories](https://github.com/FriendsOfPHP/security-advisories) repository and the [GitHub Advisory Database](https://github.com/advisories?query=ecosystem%3Acomposer).


### PR DESCRIPTION
I've added a link to the GitHub Advisory Database since this was missing from the README.md.  It was not clear to me and by lightly screening the issuelist others as well, that this was an additional source of a possible faulty security-advisory.

I think this might lead to less reports to this repository and more to the relevant repositories.

I'm also convinced a small section to the readme explaining what to do when a security advisory is probably wrong, might be helpful and could result in less issues reported here.  I do not feel confident that I could correctly write that section myself therefore I opted not to include this in this merge request.