### PR TITLE
CVE-2023-27560's affected versions are wrong

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -320,7 +320,7 @@
         "phpmyfaq/phpmyfaq": "<=3.1.7",
         "phpoffice/phpexcel": "<1.8",
         "phpoffice/phpspreadsheet": "<1.16",
-        "phpseclib/phpseclib": "<=2.0.41|>=3,<3.0.7",
+        "phpseclib/phpseclib": ">=3,<3.0.19",
         "phpservermon/phpservermon": "<=3.5.2",
         "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5,<5.6.3",
         "phpwhois/phpwhois": "<=4.2.5",


### PR DESCRIPTION
Check out the description at https://github.com/advisories/GHSA-hm7p-r324-hhf3 :

> Math/PrimeField.php in phpseclib through 2.0.41 has an infinite loop with composite primefields.

That file does not exist in 2.0.41 nor has it _ever_ existed in any tag created off of the 2.0 branch:

https://github.com/phpseclib/phpseclib/tree/2.0.41/phpseclib/Math https://github.com/phpseclib/phpseclib/tree/2.0/phpseclib/Math

That file, however, _does_ exist in the 3.0 branch:

https://github.com/phpseclib/phpseclib/blob/3.0/phpseclib/Math/PrimeField.php

The recent 3.0.19 release fixed this:

https://github.com/phpseclib/phpseclib/releases/tag/3.0.19