### PR TITLE
Allow Timber >1.24.1 and >=2.1 that contain a fix for the CVE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -594,7 +594,7 @@
         "thinkcmf/thinkcmf": "<=5.1.7",
         "thorsten/phpmyfaq": "<3.2.2",
         "tikiwiki/tiki-manager": "<=17.1",
-        "timber/timber": "<=2",
+        "timber/timber": "<1.24.1|>=2,<2.1",
         "tinymce/tinymce": "<7",
         "tinymighty/wiki-seo": "<1.2.2",
         "titon/framework": "<9.9.99",


### PR DESCRIPTION
See https://github.com/timber/timber/releases