### PR TITLE
Match jwt-framework versions with FriendsOfPHP/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -978,7 +978,7 @@
         "web-auth/webauthn-symfony-bundle": ">=5.2,<5.2.4",
         "web-feet/coastercms": "==5.5",
         "web-token/jwt-experimental": "<=4.1.6",
-        "web-token/jwt-framework": "<=4.2.99",
+        "web-token/jwt-framework": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
         "web-token/jwt-library": "<3.4.10|>=4,<4.0.7|>=4.1,<4.1.7",
         "web-tp3/wec_map": "<3.0.3",
         "webbuilders-group/silverstripe-kapost-bridge": "<0.4",


### PR DESCRIPTION
Matching versions as per https://github.com/FriendsOfPHP/security-advisories/pull/789/changes#diff-4af58925f5064620bbf9bc5563ca9aceeef7c8f576c74ad08c230dee9ddfe8b7

I think:
https://github.com/web-token/jwt-framework/security/advisories/GHSA-jc38-x7x8-2xc8
has the wrong versions on it and the problem has actually been fixed on branches
[3.4.10](https://github.com/web-token/jwt-framework/pull/651) (link is for 3.4.11, but I think it is just adding tests and fix was on 3.4.10)
[4.0.7](https://github.com/web-token/jwt-framework/pull/652)
[4.1.7](https://github.com/web-token/jwt-framework/pull/655)

but automation has pulled in the version from the GHSA

See also issues :
https://github.com/web-token/jwt-framework/issues/657
https://github.com/Roave/SecurityAdvisories/issues/152
